### PR TITLE
Fix/auth

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -9,6 +9,7 @@ const config: StorybookConfig = {
     "@chromatic-com/storybook",
     "@storybook/experimental-addon-test",
     "@storybook/addon-styling-webpack",
+    "@storybook/addon-actions",
   ],
   framework: {
     name: "@storybook/nextjs",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-intersection-observer": "^9.13.1",
-    "swiper": "^11.1.15"
+    "swiper": "^11.1.15",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3",
+    "@storybook/addon-actions": "^8.6.12",
     "@storybook/addon-essentials": "^8.6.11",
     "@storybook/addon-onboarding": "^8.6.11",
     "@storybook/addon-styling-webpack": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@vanilla-extract/css": "^1.16.1",
     "@vanilla-extract/dynamic": "^2.1.2",
     "@vanilla-extract/recipes": "^0.5.5",
+    "axios": "^1.8.4",
     "clsx": "^2.1.1",
     "jose": "^6.0.10",
     "next": "15.0.4",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@vanilla-extract/dynamic": "^2.1.2",
     "@vanilla-extract/recipes": "^0.5.5",
     "clsx": "^2.1.1",
+    "jose": "^6.0.10",
     "next": "15.0.4",
     "query-string": "^9.1.1",
     "react": "^19.0.0",

--- a/src/app/(house)/cart/page.tsx
+++ b/src/app/(house)/cart/page.tsx
@@ -1,7 +1,13 @@
-export default function CartPage() {
+"use client";
+
+import { withAuth } from "@/shared/hocs/withAuth";
+
+function CartPage() {
   return (
     <main>
       <section>Cart Page</section>
     </main>
   );
 }
+
+export default withAuth(CartPage, "protected");

--- a/src/app/(house)/cart/page.tsx
+++ b/src/app/(house)/cart/page.tsx
@@ -1,0 +1,7 @@
+export default function CartPage() {
+  return (
+    <main>
+      <section>Cart Page</section>
+    </main>
+  );
+}

--- a/src/app/(house)/layout.tsx
+++ b/src/app/(house)/layout.tsx
@@ -20,7 +20,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       setIsLoggedIn(data.isLoggedIn);
     };
     checkLoginStatus();
-  }, []);
+  }, [setIsLoggedIn]);
 
   return (
     <Suspense fallback={<></>}>

--- a/src/app/(house)/layout.tsx
+++ b/src/app/(house)/layout.tsx
@@ -1,14 +1,27 @@
+"use client";
+
+import { Suspense } from "react";
 import { NavigationBar } from "@/shared/components/NavigationBar";
 import { NAVIGATION_BAR_HEIGHT } from "@/shared/components/NavigationBar/style.css";
-import { Suspense } from "react";
+import { usePathname } from "next/navigation";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
+  const isNavRequired = pathname !== "/login";
+
   return (
-    <div>
-      <Suspense fallback={<></>}>
-        <NavigationBar />
-        <div style={{ paddingTop: NAVIGATION_BAR_HEIGHT + 1 }}>{children}</div>
-      </Suspense>
-    </div>
+    <Suspense fallback={<></>}>
+      {isNavRequired ? (
+        <>
+          <NavigationBar />
+          <div style={{ paddingTop: NAVIGATION_BAR_HEIGHT + 1 }}>
+            {children}
+          </div>
+        </>
+      ) : (
+        <div>{children}</div>
+      )}
+    </Suspense>
   );
 }

--- a/src/app/(house)/layout.tsx
+++ b/src/app/(house)/layout.tsx
@@ -1,14 +1,26 @@
 "use client";
 
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
+import { usePathname } from "next/navigation";
 import { NavigationBar } from "@/shared/components/NavigationBar";
 import { NAVIGATION_BAR_HEIGHT } from "@/shared/components/NavigationBar/style.css";
-import { usePathname } from "next/navigation";
+import { getMe } from "@/shared/api/getMe";
+import { useLoginStore } from "@/shared/store/login";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
 
+  const { setIsLoggedIn } = useLoginStore();
+
   const isNavRequired = pathname !== "/login";
+
+  useEffect(() => {
+    const checkLoginStatus = async () => {
+      const data = await getMe();
+      setIsLoggedIn(data.isLoggedIn);
+    };
+    checkLoginStatus();
+  }, []);
 
   return (
     <Suspense fallback={<></>}>

--- a/src/app/(house)/login/page.tsx
+++ b/src/app/(house)/login/page.tsx
@@ -1,0 +1,9 @@
+import { Login } from "@/features/auth/components/Login";
+
+export default function LoginPage() {
+  return (
+    <main>
+      <Login />
+    </main>
+  );
+}

--- a/src/app/(house)/login/page.tsx
+++ b/src/app/(house)/login/page.tsx
@@ -1,9 +1,12 @@
 import { Login } from "@/features/auth/components/Login";
+import * as s from "@/app/(house)/login/style.css";
 
 export default function LoginPage() {
   return (
     <main>
-      <Login />
+      <section className={s.loginSection}>
+        <Login />
+      </section>
     </main>
   );
 }

--- a/src/app/(house)/login/style.css.ts
+++ b/src/app/(house)/login/style.css.ts
@@ -1,0 +1,11 @@
+import { f } from "@/shared/styles/functions";
+import { style } from "@vanilla-extract/css";
+
+export const loginSection = style([
+  f.flexCenterBox,
+  {
+    margin: "0 auto",
+    width: "300px",
+    height: "100dvh",
+  },
+]);

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { signToken } from "@/shared/lib/auth";
+import { ACCESS_TOKEN, REFRESH_TOKEN } from "@/shared/lib/constants";
+
+export const POST = async (request: NextRequest) => {
+  try {
+    const { email, password } = await request.json();
+
+    if (email === "test@example.com" && password === "1234") {
+      const response = NextResponse.json({ success: true });
+
+      const accessToken = await signToken({ email }, "15m");
+
+      const refreshToken = await signToken({ email }, "1h");
+
+      response.cookies.set(ACCESS_TOKEN, accessToken, {
+        httpOnly: true,
+        path: "/",
+      });
+
+      response.cookies.set(REFRESH_TOKEN, refreshToken, {
+        httpOnly: true,
+        path: "/",
+      });
+
+      return response;
+    }
+
+    return NextResponse.json({ success: false }, { status: 401 });
+  } catch {
+    return NextResponse.json(
+      { success: false, message: "Internal Server Error" },
+      { status: 401 }
+    );
+  }
+};

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,11 @@
+import { ACCESS_TOKEN, REFRESH_TOKEN } from "@/shared/lib/constants";
+import { NextResponse } from "next/server";
+
+export const POST = async () => {
+  const response = NextResponse.json({ success: true });
+
+  response.cookies.set(ACCESS_TOKEN, "", { path: "/", maxAge: 0 });
+  response.cookies.set(REFRESH_TOKEN, "", { path: "/", maxAge: 0 });
+
+  return response;
+};

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { verifyAuth } from "@/shared/lib/auth";
+
+export const GET = async (request: NextRequest) => {
+  try {
+    const { email } = await verifyAuth(request);
+
+    return NextResponse.json({ isLoggedIn: true, email: email });
+  } catch (error) {
+    // accessToken 값이 존재하지 않습니다.
+    // accessToken 값이 만료되었습니다.
+    console.error(error);
+
+    return NextResponse.json({ isLoggedIn: false });
+  }
+};

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,25 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { reissueAccessToken } from "@/shared/lib/auth";
+import { ACCESS_TOKEN } from "@/shared/lib/constants";
+
+export const POST = async (request: NextRequest) => {
+  try {
+    const newAccessToken = await reissueAccessToken(request);
+
+    const response = NextResponse.json({ success: true });
+
+    response.cookies.set(ACCESS_TOKEN, newAccessToken, {
+      httpOnly: true,
+      path: "/",
+    });
+
+    return response;
+  } catch (error) {
+    console.error(error);
+
+    return NextResponse.json(
+      { success: false, message: (error as Error).message },
+      { status: 401 }
+    );
+  }
+};

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,10 +1,10 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { reissueAccessToken } from "@/shared/lib/auth";
 import { ACCESS_TOKEN } from "@/shared/lib/constants";
 
-export const POST = async (request: NextRequest) => {
+export const POST = async () => {
   try {
-    const newAccessToken = await reissueAccessToken(request);
+    const newAccessToken = await reissueAccessToken();
 
     const response = NextResponse.json({ success: true });
 
@@ -15,7 +15,9 @@ export const POST = async (request: NextRequest) => {
 
     return response;
   } catch (error) {
-    console.error(error);
+    // refreshToken 값이 존재하지 않습니다.
+    // refreshToken 값이 만료되었습니다.
+    console.error((error as Error).message);
 
     return NextResponse.json(
       { success: false, message: (error as Error).message },

--- a/src/features/auth/api/postLogin.ts
+++ b/src/features/auth/api/postLogin.ts
@@ -1,0 +1,27 @@
+import { API_BASE_URL } from "@/shared/api/constants";
+
+export type PostLoginRequest = {
+  email: string;
+  password: string;
+};
+
+export type PostLoginResponse = {
+  success: boolean;
+};
+
+const postLoginURL = `${API_BASE_URL}/api/auth/login`;
+
+export const postLogin = async (
+  payload: PostLoginRequest
+): Promise<PostLoginResponse> => {
+  const response = await fetch(postLoginURL, {
+    method: "post",
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error("Login failed");
+  }
+
+  return await response.json();
+};

--- a/src/features/auth/api/postLogin.ts
+++ b/src/features/auth/api/postLogin.ts
@@ -1,3 +1,4 @@
+import { api } from "@/shared/lib/axios";
 import { API_BASE_URL } from "@/shared/api/constants";
 
 export type PostLoginRequest = {
@@ -14,14 +15,7 @@ const postLoginURL = `${API_BASE_URL}/api/auth/login`;
 export const postLogin = async (
   payload: PostLoginRequest
 ): Promise<PostLoginResponse> => {
-  const response = await fetch(postLoginURL, {
-    method: "post",
-    body: JSON.stringify(payload),
-  });
+  const { data } = await api.post(postLoginURL, payload);
 
-  if (!response.ok) {
-    throw new Error("Login failed");
-  }
-
-  return await response.json();
+  return data;
 };

--- a/src/features/auth/api/postLogout.ts
+++ b/src/features/auth/api/postLogout.ts
@@ -1,0 +1,14 @@
+import { API_BASE_URL } from "@/shared/api/constants";
+import { api } from "@/shared/lib/axios";
+
+export type PostLogoutResponse = {
+  success: boolean;
+};
+
+const postLogoutURL = `${API_BASE_URL}/api/auth/logout`;
+
+export const postLogout = async (): Promise<PostLogoutResponse> => {
+  const { data } = await api.post(postLogoutURL);
+
+  return data;
+};

--- a/src/features/auth/components/Login/LoginForm/index.stories.tsx
+++ b/src/features/auth/components/Login/LoginForm/index.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import { LoginForm } from "@/features/auth/components/Login/LoginForm";
+
+const meta: Meta<typeof LoginForm> = {
+  component: LoginForm,
+  title: "LoginForm",
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div style={{ width: 300 }} onSubmit={(event) => event.preventDefault()}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LoginForm>;
+
+export const Default: Story = {
+  args: {
+    onChangeEmail: action("Email Changed"),
+    onChangePassword: action("Password Changed"),
+    onLogin: action("Login Submitted"),
+  },
+};

--- a/src/features/auth/components/Login/LoginForm/index.tsx
+++ b/src/features/auth/components/Login/LoginForm/index.tsx
@@ -1,0 +1,38 @@
+import { PostLoginRequest } from "@/features/auth/api/postLogin";
+import * as s from "@/features/auth/components/Login/LoginForm/style.css";
+
+type Props = PostLoginRequest & {
+  onChangeEmail: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChangePassword: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onLogin: (event: React.FormEvent<HTMLFormElement>) => void;
+};
+
+export const LoginForm = ({
+  email,
+  password,
+  onChangeEmail,
+  onChangePassword,
+  onLogin,
+}: Props) => {
+  return (
+    <form onSubmit={onLogin} className={s.form}>
+      <input
+        className={s.emailInput}
+        type="email"
+        placeholder="이메일"
+        value={email}
+        onChange={onChangeEmail}
+      />
+      <input
+        className={s.passwordInput}
+        type="password"
+        placeholder="비밀번호"
+        value={password}
+        onChange={onChangePassword}
+      />
+      <button className={s.button} type="submit">
+        로그인
+      </button>
+    </form>
+  );
+};

--- a/src/features/auth/components/Login/LoginForm/style.css.ts
+++ b/src/features/auth/components/Login/LoginForm/style.css.ts
@@ -1,0 +1,59 @@
+import { f } from "@/shared/styles/functions";
+import { style } from "@vanilla-extract/css";
+
+export const form = style([f.flex, f.directionColumn, f.wFull]);
+
+export const emailInput = style([
+  {
+    padding: "12px 16px",
+    border: "1px solid #DBDBDB",
+    borderRadius: "4px 4px 0 0",
+    fontSize: "15px",
+  },
+  {
+    selectors: {
+      "&::placeholder": {
+        color: "#BDBDBD",
+      },
+    },
+  },
+]);
+
+export const passwordInput = style([
+  {
+    marginTop: "-1px",
+    padding: "12px 16px",
+    border: "1px solid #DBDBDB",
+    borderRadius: "0 0 4px 4px",
+    fontSize: "15px",
+  },
+  {
+    selectors: {
+      "&::placeholder": {
+        color: "#BDBDBD",
+      },
+    },
+  },
+]);
+
+export const button = style([
+  {
+    marginTop: "20px",
+    padding: "15px 10px",
+    backgroundColor: "#35c5f0",
+    border: "1px solid transparent",
+    borderRadius: "4px",
+    fontWeight: 700,
+    fontSize: "16px",
+    color: "#ffffff",
+    cursor: "pointer",
+    transition: "all 0.1s",
+  },
+  {
+    selectors: {
+      "&:hover": {
+        backgroundColor: "#09ADDB",
+      },
+    },
+  },
+]);

--- a/src/features/auth/components/Login/index.tsx
+++ b/src/features/auth/components/Login/index.tsx
@@ -5,13 +5,19 @@ import { useState } from "react";
 import { usePostLogin } from "@/features/auth/hooks/usePostLogin";
 import { LoginForm } from "@/features/auth/components/Login/LoginForm";
 import { PostLoginRequest } from "@/features/auth/api/postLogin";
+import { useLoginStore } from "@/shared/store/login";
 
 export const Login = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
 
+  const { setIsLoggedIn } = useLoginStore();
+
   const { mutate: login } = usePostLogin({
-    onSuccess: () => router.push(searchParams.get("redirect") || "/"),
+    onSuccess: () => {
+      setIsLoggedIn(true);
+      router.push(searchParams.get("redirect") || "/");
+    },
   });
 
   const [email, setEmail] = useState<PostLoginRequest["email"]>("");

--- a/src/features/auth/components/Login/index.tsx
+++ b/src/features/auth/components/Login/index.tsx
@@ -1,22 +1,36 @@
 "use client";
 
 import { usePostLogin } from "@/features/auth/hooks/usePostLogin";
+import { LoginForm } from "@/features/auth/components/Login/LoginForm";
+import { useState } from "react";
+import { PostLoginRequest } from "@/features/auth/api/postLogin";
 
 export const Login = () => {
   const { mutate: login } = usePostLogin();
 
+  const [email, setEmail] = useState<PostLoginRequest["email"]>("");
+  const [password, setPassword] = useState<PostLoginRequest["password"]>("");
+
+  const handleChangeEmail = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(event.target.value);
+  };
+
+  const handleChangePassword = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setPassword(event.target.value);
+  };
+
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    login({ email: "test@example.com", password: "1234" });
+    login({ email, password });
   };
 
   return (
-    <section>
-      <form onSubmit={handleSubmit}>
-        <input type="email" placeholder="이메일" />
-        <input type="password" placeholder="비밀번호" />
-        <button type="submit">로그인</button>
-      </form>
-    </section>
+    <LoginForm
+      email={email}
+      password={password}
+      onChangeEmail={handleChangeEmail}
+      onChangePassword={handleChangePassword}
+      onLogin={handleSubmit}
+    />
   );
 };

--- a/src/features/auth/components/Login/index.tsx
+++ b/src/features/auth/components/Login/index.tsx
@@ -1,24 +1,12 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { usePostLogin } from "@/features/auth/hooks/usePostLogin";
 import { LoginForm } from "@/features/auth/components/Login/LoginForm";
 import { PostLoginRequest } from "@/features/auth/api/postLogin";
-import { useLoginStore } from "@/shared/store/login";
 
 export const Login = () => {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  const { setIsLoggedIn } = useLoginStore();
-
-  const { mutate: login } = usePostLogin({
-    onSuccess: () => {
-      setIsLoggedIn(true);
-      router.push(searchParams.get("redirect") || "/");
-    },
-  });
+  const { mutate: login } = usePostLogin();
 
   const [email, setEmail] = useState<PostLoginRequest["email"]>("");
   const [password, setPassword] = useState<PostLoginRequest["password"]>("");

--- a/src/features/auth/components/Login/index.tsx
+++ b/src/features/auth/components/Login/index.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { postLogin } from "@/features/auth/api/postLogin";
+
+export const Login = () => {
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await postLogin({ email: "test@example.com", password: "1234" });
+  };
+
+  return (
+    <section>
+      <form onSubmit={handleSubmit}>
+        <input type="email" placeholder="이메일" />
+        <input type="password" placeholder="비밀번호" />
+        <button type="submit">로그인</button>
+      </form>
+    </section>
+  );
+};

--- a/src/features/auth/components/Login/index.tsx
+++ b/src/features/auth/components/Login/index.tsx
@@ -1,12 +1,18 @@
 "use client";
 
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
 import { usePostLogin } from "@/features/auth/hooks/usePostLogin";
 import { LoginForm } from "@/features/auth/components/Login/LoginForm";
-import { useState } from "react";
 import { PostLoginRequest } from "@/features/auth/api/postLogin";
 
 export const Login = () => {
-  const { mutate: login } = usePostLogin();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const { mutate: login } = usePostLogin({
+    onSuccess: () => router.push(searchParams.get("redirect") || "/"),
+  });
 
   const [email, setEmail] = useState<PostLoginRequest["email"]>("");
   const [password, setPassword] = useState<PostLoginRequest["password"]>("");

--- a/src/features/auth/components/Login/index.tsx
+++ b/src/features/auth/components/Login/index.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { postLogin } from "@/features/auth/api/postLogin";
+import { usePostLogin } from "@/features/auth/hooks/usePostLogin";
 
 export const Login = () => {
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+  const { mutate: login } = usePostLogin();
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    await postLogin({ email: "test@example.com", password: "1234" });
+    login({ email: "test@example.com", password: "1234" });
   };
 
   return (

--- a/src/features/auth/components/Logout/LogoutButton/index.tsx
+++ b/src/features/auth/components/Logout/LogoutButton/index.tsx
@@ -1,0 +1,13 @@
+import * as s from "@/features/auth/components/Logout/LogoutButton/style.css";
+
+type Props = {
+  onLogout: () => void;
+};
+
+export const LogoutButton = ({ onLogout }: Props) => {
+  return (
+    <button className={s.button} onClick={onLogout}>
+      로그아웃
+    </button>
+  );
+};

--- a/src/features/auth/components/Logout/LogoutButton/style.css.ts
+++ b/src/features/auth/components/Logout/LogoutButton/style.css.ts
@@ -1,0 +1,15 @@
+import { style } from "@vanilla-extract/css";
+
+export const button = style([
+  {
+    padding: "0 10px",
+    backgroundColor: "transparent",
+    border: "none",
+    borderLeft: "1px solid #EAEDEF",
+    fontSize: "14px",
+    lineHeight: 1,
+    color: "#2F3438",
+    wordBreak: "keep-all",
+    cursor: "pointer",
+  },
+]);

--- a/src/features/auth/components/Logout/index.tsx
+++ b/src/features/auth/components/Logout/index.tsx
@@ -1,0 +1,13 @@
+import { LogoutButton } from "@/features/auth/components/Logout/LogoutButton";
+import { usePostLogout } from "@/features/auth/hooks/usePostLogout";
+import { useLoginStore } from "@/shared/store/login";
+
+export const Logout = () => {
+  const { setIsLoggedIn } = useLoginStore();
+
+  const { mutate: logout } = usePostLogout({
+    onSuccess: () => setIsLoggedIn(false),
+  });
+
+  return <LogoutButton onLogout={logout} />;
+};

--- a/src/features/auth/components/Logout/index.tsx
+++ b/src/features/auth/components/Logout/index.tsx
@@ -1,13 +1,8 @@
 import { LogoutButton } from "@/features/auth/components/Logout/LogoutButton";
 import { usePostLogout } from "@/features/auth/hooks/usePostLogout";
-import { useLoginStore } from "@/shared/store/login";
 
 export const Logout = () => {
-  const { setIsLoggedIn } = useLoginStore();
-
-  const { mutate: logout } = usePostLogout({
-    onSuccess: () => setIsLoggedIn(false),
-  });
+  const { mutate: logout } = usePostLogout();
 
   return <LogoutButton onLogout={logout} />;
 };

--- a/src/features/auth/hooks/usePostLogin.ts
+++ b/src/features/auth/hooks/usePostLogin.ts
@@ -1,0 +1,12 @@
+import { useMutation } from "@tanstack/react-query";
+import {
+  PostLoginRequest,
+  PostLoginResponse,
+  postLogin,
+} from "@/features/auth/api/postLogin";
+
+export const usePostLogin = () => {
+  return useMutation<PostLoginResponse, Error, PostLoginRequest, unknown>({
+    mutationFn: postLogin,
+  });
+};

--- a/src/features/auth/hooks/usePostLogin.ts
+++ b/src/features/auth/hooks/usePostLogin.ts
@@ -1,20 +1,24 @@
-import { UseMutationOptions, useMutation } from "@tanstack/react-query";
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useMutation } from "@tanstack/react-query";
 import {
   PostLoginRequest,
   PostLoginResponse,
   postLogin,
 } from "@/features/auth/api/postLogin";
+import { useLoginStore } from "@/shared/store/login";
 
-export const usePostLogin = (
-  options?: UseMutationOptions<
-    PostLoginResponse,
-    Error,
-    PostLoginRequest,
-    unknown
-  >
-) => {
+export const usePostLogin = () => {
+  const searchParams = useSearchParams();
+
+  const { setIsLoggedIn } = useLoginStore();
+
   return useMutation<PostLoginResponse, Error, PostLoginRequest, unknown>({
     mutationFn: postLogin,
-    ...options,
+    onSuccess: () => {
+      setIsLoggedIn(true);
+      window.location.assign(searchParams.get("redirect") || "/");
+    },
   });
 };

--- a/src/features/auth/hooks/usePostLogin.ts
+++ b/src/features/auth/hooks/usePostLogin.ts
@@ -1,23 +1,26 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   PostLoginRequest,
   PostLoginResponse,
   postLogin,
 } from "@/features/auth/api/postLogin";
 import { useLoginStore } from "@/shared/store/login";
+import { getMeURL } from "@/shared/api/getMe";
 
 export const usePostLogin = () => {
+  const queryClient = useQueryClient();
   const searchParams = useSearchParams();
 
   const { setIsLoggedIn } = useLoginStore();
 
   return useMutation<PostLoginResponse, Error, PostLoginRequest, unknown>({
     mutationFn: postLogin,
-    onSuccess: () => {
+    onSuccess: async () => {
       setIsLoggedIn(true);
+      await queryClient.invalidateQueries({ queryKey: ["getMe", getMeURL] });
       window.location.assign(searchParams.get("redirect") || "/");
     },
   });

--- a/src/features/auth/hooks/usePostLogin.ts
+++ b/src/features/auth/hooks/usePostLogin.ts
@@ -1,12 +1,20 @@
-import { useMutation } from "@tanstack/react-query";
+import { UseMutationOptions, useMutation } from "@tanstack/react-query";
 import {
   PostLoginRequest,
   PostLoginResponse,
   postLogin,
 } from "@/features/auth/api/postLogin";
 
-export const usePostLogin = () => {
+export const usePostLogin = (
+  options?: UseMutationOptions<
+    PostLoginResponse,
+    Error,
+    PostLoginRequest,
+    unknown
+  >
+) => {
   return useMutation<PostLoginResponse, Error, PostLoginRequest, unknown>({
     mutationFn: postLogin,
+    ...options,
   });
 };

--- a/src/features/auth/hooks/usePostLogout.ts
+++ b/src/features/auth/hooks/usePostLogout.ts
@@ -1,11 +1,17 @@
-import { UseMutationOptions, useMutation } from "@tanstack/react-query";
-import { PostLogoutResponse, postLogout } from "@/features/auth/api/postLogout";
+"use client";
 
-export const usePostLogout = (
-  options?: UseMutationOptions<PostLogoutResponse, Error, void, unknown>
-) => {
+import { useMutation } from "@tanstack/react-query";
+import { PostLogoutResponse, postLogout } from "@/features/auth/api/postLogout";
+import { useLoginStore } from "@/shared/store/login";
+
+export const usePostLogout = () => {
+  const { setIsLoggedIn } = useLoginStore();
+
   return useMutation<PostLogoutResponse, Error, void>({
     mutationFn: postLogout,
-    ...options,
+    onSuccess: () => {
+      setIsLoggedIn(false);
+      window.location.assign("/login");
+    },
   });
 };

--- a/src/features/auth/hooks/usePostLogout.ts
+++ b/src/features/auth/hooks/usePostLogout.ts
@@ -1,16 +1,19 @@
 "use client";
 
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { PostLogoutResponse, postLogout } from "@/features/auth/api/postLogout";
 import { useLoginStore } from "@/shared/store/login";
+import { getMeURL } from "@/shared/api/getMe";
 
 export const usePostLogout = () => {
+  const queryClient = useQueryClient();
   const { setIsLoggedIn } = useLoginStore();
 
   return useMutation<PostLogoutResponse, Error, void>({
     mutationFn: postLogout,
-    onSuccess: () => {
+    onSuccess: async () => {
       setIsLoggedIn(false);
+      await queryClient.invalidateQueries({ queryKey: ["getMe", getMeURL] });
       window.location.assign("/login");
     },
   });

--- a/src/features/auth/hooks/usePostLogout.ts
+++ b/src/features/auth/hooks/usePostLogout.ts
@@ -1,0 +1,11 @@
+import { UseMutationOptions, useMutation } from "@tanstack/react-query";
+import { PostLogoutResponse, postLogout } from "@/features/auth/api/postLogout";
+
+export const usePostLogout = (
+  options?: UseMutationOptions<PostLogoutResponse, Error, void, unknown>
+) => {
+  return useMutation<PostLogoutResponse, Error, void>({
+    mutationFn: postLogout,
+    ...options,
+  });
+};

--- a/src/features/goods/detail/api/getGoodsDetail.ts
+++ b/src/features/goods/detail/api/getGoodsDetail.ts
@@ -1,3 +1,4 @@
+import { api } from "@/shared/lib/axios";
 import { API_BASE_URL } from "@/shared/api/constants";
 
 export type GetGoodsDetailRequestParams = {
@@ -65,7 +66,7 @@ export const getGoodsDetail = async (
 ): Promise<GetGoodsDetailResponse> => {
   const url = GetGoodsDetailURL.replace(":goodId", params.goodId);
 
-  const response = await fetch(url);
+  const { data } = await api.get(url);
 
-  return await response.json();
+  return data;
 };

--- a/src/features/main/api/getGoods.ts
+++ b/src/features/main/api/getGoods.ts
@@ -1,7 +1,8 @@
+import queryString from "query-string";
 import { API_BASE_URL } from "@/shared/api/constants";
 import { Good } from "@/shared/api/house/types/item";
 import { ListResponse } from "@/shared/api/house/types/list";
-import queryString from "query-string";
+import { api } from "@/shared/lib/axios";
 
 export type Order =
   | "recommended"
@@ -26,7 +27,7 @@ export const getGoods = async (
 
   const url = `${getGoodsURL}?${searchParams}`;
 
-  const response = await fetch(url);
+  const { data } = await api.get(url);
 
-  return await response.json();
+  return data;
 };

--- a/src/features/search/api/getSearchGoods.ts
+++ b/src/features/search/api/getSearchGoods.ts
@@ -1,6 +1,7 @@
+import queryString from "query-string";
 import { GetGoodsResponse, Order } from "@/features/main/api/getGoods";
 import { API_BASE_URL } from "@/shared/api/constants";
-import queryString from "query-string";
+import { api } from "@/shared/lib/axios";
 
 export type GetSearchGoodsRequestParams = {
   q: string;
@@ -18,7 +19,7 @@ export const getSearchGoods = async (
 
   const url = `${getSearchGoodsURL}?${searchParams}`;
 
-  const response = await fetch(url);
+  const { data } = await api.get(url);
 
-  return await response.json();
+  return data;
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,28 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { verifyAuth } from "@/shared/lib/auth";
+import { ACCESS_TOKEN } from "@/shared/lib/constants";
+
+export const middleware = async (request: NextRequest) => {
+  const accessToken = request.cookies.get(ACCESS_TOKEN)?.value;
+
+  if (!accessToken) {
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("redirect", request.nextUrl.pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  try {
+    await verifyAuth(request);
+    return NextResponse.next();
+  } catch (error) {
+    console.error(error);
+
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("redirect", request.nextUrl.pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+};
+
+export const config = {
+  matcher: ["/cart"],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,12 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { reissueAccessToken, verifyAuth } from "@/shared/lib/auth";
-import {
-  ACCESS_TOKEN,
-  GUEST_PATHS,
-  MATCHER_PATHS,
-  PROTECTED_PATHS,
-  REFRESH_TOKEN,
-} from "@/shared/lib/constants";
+import { ACCESS_TOKEN, REFRESH_TOKEN } from "@/shared/lib/constants";
 
 const redirectToLogin = (request: NextRequest) => {
   const loginUrl = new URL("/login", request.url);
@@ -93,6 +87,10 @@ export const middleware = async (request: NextRequest) => {
   return NextResponse.next();
 };
 
+const GUEST_PATHS = ["/login"];
+
+const PROTECTED_PATHS = ["/cart"];
+
 export const config = {
-  matcher: MATCHER_PATHS,
+  matcher: ["/login", "/cart"],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,12 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { reissueAccessToken, verifyAuth } from "@/shared/lib/auth";
-import { ACCESS_TOKEN, REFRESH_TOKEN } from "@/shared/lib/constants";
+import {
+  ACCESS_TOKEN,
+  GUEST_PATHS,
+  MATCHER_PATHS,
+  PROTECTED_PATHS,
+  REFRESH_TOKEN,
+} from "@/shared/lib/constants";
 
 const redirectToLogin = (request: NextRequest) => {
   const loginUrl = new URL("/login", request.url);
@@ -12,39 +18,81 @@ export const middleware = async (request: NextRequest) => {
   const accessToken = request.cookies.get(ACCESS_TOKEN)?.value;
   const refreshToken = request.cookies.get(REFRESH_TOKEN)?.value;
 
-  if (!accessToken) {
-    return redirectToLogin(request);
+  const isGuestPath = GUEST_PATHS.includes(request.nextUrl.pathname);
+  const isProtectedPath = PROTECTED_PATHS.includes(request.nextUrl.pathname);
+
+  if (isGuestPath) {
+    if (accessToken) {
+      try {
+        await verifyAuth(request);
+        return NextResponse.redirect(new URL("/", request.url));
+      } catch (error) {
+        // accessToken 만료
+        console.error(error);
+
+        if (refreshToken) {
+          try {
+            const newAccessToken = await reissueAccessToken(request);
+
+            const response = NextResponse.redirect(new URL("/", request.url));
+
+            response.cookies.set(ACCESS_TOKEN, newAccessToken, {
+              httpOnly: true,
+              path: "/",
+            });
+
+            return response;
+          } catch (error) {
+            // refreshToken 만료
+            console.error(error);
+
+            // 그대로 진행
+            return NextResponse.next();
+          }
+        }
+      }
+    }
   }
 
-  try {
-    await verifyAuth(request);
-    return NextResponse.next();
-  } catch (error) {
-    console.error(error);
-
-    if (!refreshToken) {
+  if (isProtectedPath) {
+    if (!accessToken) {
       return redirectToLogin(request);
     }
 
     try {
-      const newAccessToken = await reissueAccessToken(request);
-
-      const response = NextResponse.next();
-
-      response.cookies.set(ACCESS_TOKEN, newAccessToken, {
-        httpOnly: true,
-        path: "/",
-      });
-
-      return response;
+      await verifyAuth(request);
+      return NextResponse.next();
     } catch (error) {
+      // accessToken 만료
       console.error(error);
 
-      return redirectToLogin(request);
+      if (!refreshToken) {
+        return redirectToLogin(request);
+      }
+
+      try {
+        const newAccessToken = await reissueAccessToken(request);
+
+        const response = NextResponse.next();
+
+        response.cookies.set(ACCESS_TOKEN, newAccessToken, {
+          httpOnly: true,
+          path: "/",
+        });
+
+        return response;
+      } catch (error) {
+        // refreshToken 만료
+        console.error(error);
+
+        return redirectToLogin(request);
+      }
     }
   }
+
+  return NextResponse.next();
 };
 
 export const config = {
-  matcher: ["/cart"],
+  matcher: MATCHER_PATHS,
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -92,5 +92,5 @@ const GUEST_PATHS = ["/login"];
 const PROTECTED_PATHS = ["/cart"];
 
 export const config = {
-  matcher: ["/login", "/cart"],
+  matcher: ["/((?!api|_next/static|_next/image|.*\\.png$).*)"],
 };

--- a/src/shared/api/getMe.ts
+++ b/src/shared/api/getMe.ts
@@ -1,0 +1,15 @@
+import { api } from "@/shared/lib/axios";
+import { API_BASE_URL } from "@/shared/api/constants";
+
+export type GetMeResponse = {
+  isLoggedIn: boolean;
+  email?: string;
+};
+
+export const getMeURL = `${API_BASE_URL}/api/auth/me`;
+
+export const getMe = async (): Promise<GetMeResponse> => {
+  const { data } = await api.get(getMeURL);
+
+  return data;
+};

--- a/src/shared/api/getMe.ts
+++ b/src/shared/api/getMe.ts
@@ -1,9 +1,10 @@
+import { type JWTPayload } from "jose";
 import { api } from "@/shared/lib/axios";
 import { API_BASE_URL } from "@/shared/api/constants";
 
 export type GetMeResponse = {
   isLoggedIn: boolean;
-  email?: string;
+  user?: JWTPayload;
 };
 
 export const getMeURL = `${API_BASE_URL}/api/auth/me`;

--- a/src/shared/components/NavigationBar/index.tsx
+++ b/src/shared/components/NavigationBar/index.tsx
@@ -17,7 +17,22 @@ export const NavigationBar = () => {
         <div className={s.centerWrapper}>
           <SearchForm />
         </div>
-        <div className={s.endWrapper}></div>
+        <div className={s.endWrapper}>
+          <Link
+            href="/cart"
+            className={s.pageLink}
+            aria-label="장바구니 페이지로 이동"
+          >
+            장바구니
+          </Link>
+          <Link
+            href="/login"
+            className={s.pageLink}
+            aria-label="로그인 페이지로 이동"
+          >
+            로그인
+          </Link>
+        </div>
       </div>
     </nav>
   );

--- a/src/shared/components/NavigationBar/index.tsx
+++ b/src/shared/components/NavigationBar/index.tsx
@@ -1,9 +1,15 @@
+"use client";
+
 import Link from "next/link";
-import Logo from "./logo.svg";
+import Logo from "@/shared/components/NavigationBar/logo.svg";
+import { SearchForm } from "@/shared/components/NavigationBar/SearchForm";
+import { useLoginStore } from "@/shared/store/login";
 import * as s from "./style.css";
-import { SearchForm } from "./SearchForm";
+import { Logout } from "@/features/auth/components/Logout";
 
 export const NavigationBar = () => {
+  const { isLoggedIn } = useLoginStore();
+
   return (
     <nav className={s.container}>
       <div className={s.wrapper}>
@@ -25,13 +31,17 @@ export const NavigationBar = () => {
           >
             장바구니
           </Link>
-          <Link
-            href="/login"
-            className={s.pageLink}
-            aria-label="로그인 페이지로 이동"
-          >
-            로그인
-          </Link>
+          {isLoggedIn ? (
+            <Logout />
+          ) : (
+            <Link
+              href="/login"
+              className={s.pageLink}
+              aria-label="로그인 페이지로 이동"
+            >
+              로그인
+            </Link>
+          )}
         </div>
       </div>
     </nav>

--- a/src/shared/components/NavigationBar/style.css.ts
+++ b/src/shared/components/NavigationBar/style.css.ts
@@ -43,13 +43,14 @@ export const wrapper = style([
 export const link = style([
   {
     display: "inline-block",
+    paddingRight: "10px",
   },
 ]);
 
 export const logo = style([
   {
-    width: "71px",
-    height: "28px",
+    width: "75px",
+    height: "29px",
   },
 ]);
 
@@ -66,12 +67,27 @@ export const centerWrapper = style([
 ]);
 
 export const endWrapper = style([
-  responsiveStyle({
-    md: {
-      flex: 1,
+  f.flex,
+  {
+    flex: 1,
+    justifyContent: "right",
+  },
+]);
+
+export const pageLink = style([
+  {
+    padding: "0 10px",
+    display: "inline-block",
+    fontSize: "14px",
+    color: "#2F3438",
+    textDecoration: "none",
+    wordBreak: "keep-all",
+  },
+  {
+    selectors: {
+      "&:not(:first-child)": {
+        borderLeft: "1px solid #EAEDEF",
+      },
     },
-    sm: {
-      flex: 0,
-    },
-  }),
+  },
 ]);

--- a/src/shared/hocs/withAuth.tsx
+++ b/src/shared/hocs/withAuth.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useGetMe } from "@/shared/hooks/useGetMe";
+import { JSX, useEffect } from "react";
+
+type AuthType = "public" | "guest-only" | "protected";
+
+export function withAuth<P>(
+  Component: React.ComponentType<P>,
+  type: AuthType = "public"
+) {
+  return function AuthWrapper(props: P) {
+    const router = useRouter();
+    const { data: session, isLoading } = useGetMe();
+
+    useEffect(() => {
+      if (isLoading) return;
+
+      if (type === "protected" && !session.isLoggedIn) {
+        router.replace("/login");
+      }
+
+      if (type === "guest-only" && session.isLoggedIn) {
+        router.replace("/");
+      }
+    }, [session.isLoggedIn, isLoading, router]);
+
+    if (isLoading) return null;
+    if (type === "protected" && !session.isLoggedIn) return null;
+    if (type === "guest-only" && session.isLoggedIn) return null;
+
+    return <Component {...(props as P & JSX.IntrinsicAttributes)} />;
+  };
+}

--- a/src/shared/hooks/useGetMe.ts
+++ b/src/shared/hooks/useGetMe.ts
@@ -1,0 +1,12 @@
+import {
+  UseSuspenseQueryResult,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { GetMeResponse, getMe, getMeURL } from "@/shared/api/getMe";
+
+export const useGetMe = (): UseSuspenseQueryResult<GetMeResponse, Error> => {
+  return useSuspenseQuery({
+    queryKey: ["getMe", getMeURL],
+    queryFn: async () => getMe(),
+  });
+};

--- a/src/shared/lib/auth.ts
+++ b/src/shared/lib/auth.ts
@@ -1,0 +1,10 @@
+import { JWTPayload, SignJWT } from "jose";
+import { SECRET } from "@/shared/lib/constants";
+
+export const signToken = async (payload: JWTPayload, expiresIn: string) => {
+  return await new SignJWT(payload)
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime(expiresIn)
+    .sign(SECRET);
+};

--- a/src/shared/lib/auth.ts
+++ b/src/shared/lib/auth.ts
@@ -1,5 +1,6 @@
-import { JWTPayload, SignJWT } from "jose";
-import { SECRET } from "@/shared/lib/constants";
+import type { NextRequest } from "next/server";
+import { JWTPayload, SignJWT, jwtVerify } from "jose";
+import { ACCESS_TOKEN, SECRET } from "@/shared/lib/constants";
 
 export const signToken = async (payload: JWTPayload, expiresIn: string) => {
   return await new SignJWT(payload)
@@ -7,4 +8,18 @@ export const signToken = async (payload: JWTPayload, expiresIn: string) => {
     .setIssuedAt()
     .setExpirationTime(expiresIn)
     .sign(SECRET);
+};
+
+export const verifyAuth = async (request: NextRequest) => {
+  const accessToken = request.cookies.get(ACCESS_TOKEN)?.value;
+
+  if (!accessToken) throw new Error("accessToken 값이 존재하지 않습니다.");
+
+  try {
+    const verified = await jwtVerify(accessToken, SECRET);
+
+    return verified.payload;
+  } catch {
+    throw new Error("accessToken 값이 만료되었습니다.");
+  }
 };

--- a/src/shared/lib/auth.ts
+++ b/src/shared/lib/auth.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from "next/server";
 import { JWTPayload, SignJWT, jwtVerify } from "jose";
-import { ACCESS_TOKEN, SECRET } from "@/shared/lib/constants";
+import { ACCESS_TOKEN, REFRESH_TOKEN, SECRET } from "@/shared/lib/constants";
 
 export const signToken = async (payload: JWTPayload, expiresIn: string) => {
   return await new SignJWT(payload)
@@ -21,5 +21,19 @@ export const verifyAuth = async (request: NextRequest) => {
     return verified.payload;
   } catch {
     throw new Error("accessToken 값이 만료되었습니다.");
+  }
+};
+
+export const reissueAccessToken = async (request: NextRequest) => {
+  const refreshToken = request.cookies.get(REFRESH_TOKEN)?.value;
+
+  if (!refreshToken) throw new Error("refreshToken 값이 존재하지 않습니다.");
+
+  try {
+    const { payload } = await jwtVerify(refreshToken, SECRET);
+
+    return await signToken({ email: payload.email }, "15m");
+  } catch {
+    throw new Error("refreshToken 값이 만료되었습니다.");
   }
 };

--- a/src/shared/lib/axios.ts
+++ b/src/shared/lib/axios.ts
@@ -22,7 +22,11 @@ api.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    if (error.response.status === 401 && !originalRequest._retry) {
+    if (
+      error.response.status === 401 &&
+      !originalRequest._retry &&
+      !originalRequest.url?.includes("/api/auth/login")
+    ) {
       originalRequest._retry = true;
 
       try {

--- a/src/shared/lib/axios.ts
+++ b/src/shared/lib/axios.ts
@@ -1,0 +1,36 @@
+import axios, {
+  AxiosError,
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+} from "axios";
+
+export const api: AxiosInstance = axios.create({
+  baseURL: "/api",
+  withCredentials: true,
+});
+
+api.interceptors.response.use(
+  (response: AxiosResponse) => response,
+  async (error: AxiosError) => {
+    const originalRequest = error.config as AxiosRequestConfig & {
+      _retry: boolean;
+    };
+
+    if (!error.response) {
+      alert("네트워크 오류가 발생했습니다.");
+      return Promise.reject(error);
+    }
+
+    if (error.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      try {
+        await api.post("/auth/refresh");
+        return api(originalRequest);
+      } catch {
+        window.location.href = "/login";
+      }
+    }
+  }
+);

--- a/src/shared/lib/constants.ts
+++ b/src/shared/lib/constants.ts
@@ -13,9 +13,3 @@ export const SECRET = new TextEncoder().encode(getJwtSecret());
 export const ACCESS_TOKEN = "accessToken";
 
 export const REFRESH_TOKEN = "refreshToken";
-
-export const GUEST_PATHS = ["/login"];
-
-export const PROTECTED_PATHS = ["/cart"];
-
-export const MATCHER_PATHS = [...GUEST_PATHS, ...PROTECTED_PATHS];

--- a/src/shared/lib/constants.ts
+++ b/src/shared/lib/constants.ts
@@ -13,3 +13,9 @@ export const SECRET = new TextEncoder().encode(getJwtSecret());
 export const ACCESS_TOKEN = "accessToken";
 
 export const REFRESH_TOKEN = "refreshToken";
+
+export const GUEST_PATHS = ["/login"];
+
+export const PROTECTED_PATHS = ["/cart"];
+
+export const MATCHER_PATHS = [...GUEST_PATHS, ...PROTECTED_PATHS];

--- a/src/shared/lib/constants.ts
+++ b/src/shared/lib/constants.ts
@@ -1,0 +1,15 @@
+const JWT_SECRET: string | undefined = process.env.JWT_SECRET!;
+
+export const getJwtSecret = () => {
+  if (!JWT_SECRET || JWT_SECRET.length === 0) {
+    throw new Error("JWT_SECRET 환경변수가 설정되지 않았습니다.");
+  }
+
+  return JWT_SECRET;
+};
+
+export const SECRET = new TextEncoder().encode(getJwtSecret());
+
+export const ACCESS_TOKEN = "accessToken";
+
+export const REFRESH_TOKEN = "refreshToken";

--- a/src/shared/lib/session.ts
+++ b/src/shared/lib/session.ts
@@ -1,0 +1,33 @@
+import { cookies } from "next/headers";
+import { ACCESS_TOKEN } from "@/shared/lib/constants";
+import { reissueAccessToken, verifyJwt } from "@/shared/lib/auth";
+
+export const getSession = async () => {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get(ACCESS_TOKEN)?.value;
+
+  if (!accessToken) throw new Error(`${ACCESS_TOKEN} 값이 존재하지 않습니다.`);
+
+  try {
+    const payload = await verifyJwt(ACCESS_TOKEN, accessToken);
+
+    return payload ? { user: payload } : null;
+  } catch (error) {
+    // accessToken 값이 만료되었습니다.
+    console.error((error as Error).message);
+
+    try {
+      const newAccessToken = await reissueAccessToken();
+
+      const payload = await verifyJwt(ACCESS_TOKEN, newAccessToken);
+
+      return payload ? { user: payload, newAccessToken } : null;
+    } catch (error) {
+      // refreshToken 값이 존재하지 않습니다.
+      // refreshToken 값이 만료되었습니다.
+      console.error((error as Error).message);
+
+      return null;
+    }
+  }
+};

--- a/src/shared/store/login.ts
+++ b/src/shared/store/login.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+type LoginState = {
+  isLoggedIn: boolean;
+  setIsLoggedIn: (status: boolean) => void;
+};
+
+export const useLoginStore = create<LoginState>((set) => ({
+  isLoggedIn: false,
+  setIsLoggedIn: (status) => set({ isLoggedIn: status }),
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -9060,3 +9060,8 @@ yoctocolors-cjs@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz#f4b905a840a37506813a7acaa28febe97767a242"
   integrity sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==
+
+zustand@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.3.tgz#b323435b73d06b2512e93c77239634374b0e407f"
+  integrity sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6207,6 +6207,11 @@ jiti@^1.20.0:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.7.tgz#9dd81043424a3d28458b193d965f0d18a2300ba9"
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
 
+jose@^6.0.10:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.0.10.tgz#52d96e1a671b4c02e13b71e0d35abea2e774712b"
+  integrity sha512-skIAxZqcMkOrSwjJvplIPYrlXGpxTPnro2/QWTDCxAdWQrSTV5/KqspMWmi5WAx5+ULswASJiZ0a+1B/Lxt9cw==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3706,6 +3706,11 @@ ast-types@^0.16.1:
   dependencies:
     tslib "^2.0.1"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
@@ -3717,6 +3722,15 @@ axe-core@^4.10.0:
   version "4.10.2"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.2.tgz#85228e3e1d8b8532a27659b332e39b7fa0e022df"
   integrity sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==
+
+axios@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
+  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^4.1.0:
   version "4.1.0"
@@ -4156,6 +4170,13 @@ colorette@^2.0.10:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -4512,6 +4533,11 @@ define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
 dequal@^2.0.2, dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
@@ -4863,6 +4889,16 @@ es-set-tostringtag@^2.0.3:
     get-intrinsic "^1.2.4"
     has-tostringtag "^1.0.2"
     hasown "^2.0.1"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 es-shim-unscopables@^1.0.0, es-shim-unscopables@^1.0.2:
   version "1.0.2"
@@ -5411,6 +5447,11 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.2.tgz#adba1448a9841bec72b42c532ea23dbbedef1a27"
   integrity sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==
 
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -5450,6 +5491,16 @@ fork-ts-checker-webpack-plugin@^8.0.0:
     schema-utils "^3.1.1"
     semver "^7.3.5"
     tapable "^2.2.1"
+
+form-data@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.2.tgz#35cabbdd30c3ce73deb2c42d3c8d3ed9ca51794c"
+  integrity sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    mime-types "^2.1.12"
 
 fs-extra@^10.0.0:
   version "10.1.0"
@@ -5524,7 +5575,7 @@ get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@^1.2.4:
     has-symbols "^1.1.0"
     hasown "^2.0.2"
 
-get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -6536,7 +6587,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.27, mime-types@^2.1.31:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -7274,6 +7325,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.15.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2212,6 +2212,17 @@
     polished "^4.2.2"
     uuid "^9.0.0"
 
+"@storybook/addon-actions@^8.6.12":
+  version "8.6.12"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-8.6.12.tgz#b3a0ded04e0318f9dcad12c8946ae66426e0700e"
+  integrity sha512-B5kfiRvi35oJ0NIo53CGH66H471A3XTzrfaa6SxXEJsgxxSeKScG5YeXcCvLiZfvANRQ7QDsmzPUgg0o3hdMXw==
+  dependencies:
+    "@storybook/global" "^5.0.0"
+    "@types/uuid" "^9.0.1"
+    dequal "^2.0.2"
+    polished "^4.2.2"
+    uuid "^9.0.0"
+
 "@storybook/addon-backgrounds@8.6.11":
   version "8.6.11"
   resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-8.6.11.tgz#8543efb5ee896badb61f94338e41f9450a7a0204"


### PR DESCRIPTION
feat: 로그인 api 생성
feat: 로그인 hooks 생성
feat: 로그인 컴포넌트 구현 및 스타일링
feat: 라우팅 보호를 위한 middleware.ts 추가
feat: refresh api 생성
feat: middleware.ts에 accessToken 만료 시 refreshToken으로 재발급 받는 로직 추가
refactor: axios 인스턴스(api) 생성 및 응답 인터셉터 설정, 기존 fetch 함수를 api로 변경
refactor: middleware.ts에 GUEST_PATHS, PROTECTED_PATHS 분기 로직 추가
feat: 로그인 성공 시 redirect 파라미터 또는 홈으로 이동하도록 처리
fix: 응답 인터셉터 분기 처리로 /auth/refresh API 무한 호출 버그 해결
feat: 네비게이션 바에 장바구니와 로그인 페이지 링크 추가
feat: LoginForm 컴포넌트에 대한 스토리 작성
feat: /api/auth/me 기반 로그인 상태 저장 및 네비게이션 로그인/로그아웃 분기 처리
fix: middleware config matcher에 동적 값 대신 상수 배열 할당하여 빌드 에러 해결
fix: 로그인 후 router.push 가 아닌 window.location.assgin을 사용함으로써 서버 요청 강제
refactor: 미들웨어와 API Route의 쿠키 접근 방식 차이로 인해 auth 함수 분리
feat: 페이지 접근 제어를 위한 클라이언트 Auth Guard 로직 구현