### PR TITLE
Release: dev → main

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.62.3",
-    "@tanstack/react-query-next-experimental": "^5.62.3",
+    "@tanstack/react-query-devtools": "^5.76.1",
     "@vanilla-extract/css": "^1.16.1",
     "@vanilla-extract/dynamic": "^2.1.2",
     "@vanilla-extract/recipes": "^0.5.5",

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.7.3'
+const PACKAGE_VERSION = '2.6.8'
 const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/src/app/(house)/goods/[goodId]/page.tsx
+++ b/src/app/(house)/goods/[goodId]/page.tsx
@@ -1,19 +1,25 @@
+import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
 import { GetGoodsDetailRequestParams } from "@/features/goods/detail/api/getGoodsDetail";
 import { GoodDetail } from "@/features/goods/detail/components/GoodDetail";
-import { Suspense } from "react";
+import { goodDetailQueryOptions } from "@/features/goods/detail/queries/goodDetail";
+import { getQueryClient } from "@/shared/lib/react-query";
 
-export type GoodDetailPageParams = {
-  params: Promise<GetGoodsDetailRequestParams>;
+type Props = {
+  params: Promise<Pick<GetGoodsDetailRequestParams, "goodId">>;
 };
 
-export default async function GoodDetailPage({ params }: GoodDetailPageParams) {
-  const goodId = (await params).goodId;
+export default async function GoodDetailPage({ params }: Props) {
+  const { goodId } = await params;
+
+  const queryClient = getQueryClient();
+
+  await queryClient.prefetchQuery(goodDetailQueryOptions({ goodId }));
 
   return (
     <main>
-      <Suspense fallback={<></>}>
+      <HydrationBoundary state={dehydrate(queryClient)}>
         <GoodDetail goodId={goodId} />
-      </Suspense>
+      </HydrationBoundary>
     </main>
   );
 }

--- a/src/app/(house)/page.tsx
+++ b/src/app/(house)/page.tsx
@@ -1,8 +1,22 @@
+import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
+import { goodsInfiniteQueryOptions } from "@/features/main/queries/goods";
+import { GetGoodsRequestParams } from "@/features/main/api/getGoods";
 import { Filters } from "@/features/main/components/Filters";
 import { MainGoods } from "@/features/main/components/MainGoods";
+import { getQueryClient } from "@/shared/lib/react-query";
 import * as s from "@/app/(house)/style.css";
 
-export default function Home() {
+type Props = {
+  searchParams: Promise<Partial<Pick<GetGoodsRequestParams, "order">>>;
+};
+
+export default async function Home({ searchParams }: Props) {
+  const { order = "recommended" } = await searchParams;
+
+  const queryClient = getQueryClient();
+
+  await queryClient.prefetchInfiniteQuery(goodsInfiniteQueryOptions({ order }));
+
   return (
     <main>
       <div
@@ -18,7 +32,9 @@ export default function Home() {
         <Filters />
       </div>
       <section className={s.mainGoodsSection}>
-        <MainGoods />
+        <HydrationBoundary state={dehydrate(queryClient)}>
+          <MainGoods order={order} />
+        </HydrationBoundary>
       </section>
     </main>
   );

--- a/src/app/(house)/search/page.tsx
+++ b/src/app/(house)/search/page.tsx
@@ -1,28 +1,45 @@
-import { Suspense } from "react";
+import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
+import { searchGoodsInfiniteQueryOptions } from "@/features/search/queries/searchGoods";
+import { GetSearchGoodsRequestParams } from "@/features/search/api/getSearchGoods";
 import { Filters } from "@/features/main/components/Filters";
 import { SearchGoods } from "@/features/search/components/SearchGoods";
+import { getQueryClient } from "@/shared/lib/react-query";
 import * as s from "@/app/(house)/search/style.css";
 
-export default function Search() {
+type Props = {
+  searchParams: Promise<
+    Partial<Pick<GetSearchGoodsRequestParams, "q" | "order">>
+  >;
+};
+
+export default async function Search({ searchParams }: Props) {
+  const { q = "", order = "recommended" } = await searchParams;
+
+  const queryClient = getQueryClient();
+
+  await queryClient.prefetchInfiniteQuery(
+    searchGoodsInfiniteQueryOptions({ q, order })
+  );
+
   return (
     <main>
-      <Suspense fallback={<></>}>
-        <div
-          style={{
-            position: "fixed",
-            top: 81,
-            left: 0,
-            zIndex: 8000,
-            width: "100%",
-            backgroundColor: "#ffffff",
-          }}
-        >
-          <Filters />
-        </div>
-        <section className={s.searchGoodsSection}>
-          <SearchGoods />
-        </section>
-      </Suspense>
+      <div
+        style={{
+          position: "fixed",
+          top: 81,
+          left: 0,
+          zIndex: 8000,
+          width: "100%",
+          backgroundColor: "#ffffff",
+        }}
+      >
+        <Filters />
+      </div>
+      <section className={s.searchGoodsSection}>
+        <HydrationBoundary state={dehydrate(queryClient)}>
+          <SearchGoods q={q} order={order} />
+        </HydrationBoundary>
+      </section>
     </main>
   );
 }

--- a/src/app/api/goods/search/route.ts
+++ b/src/app/api/goods/search/route.ts
@@ -6,7 +6,7 @@ import { rawGood } from "@/shared/api/house/types/item";
 export const GET = async (request: NextRequest) => {
   try {
     const searchParams = parseSearchParams(request.nextUrl.searchParams);
-    const { q, order } = searchParams;
+    const { q, order, page } = searchParams;
 
     const data = [
       {
@@ -827,7 +827,17 @@ export const GET = async (request: NextRequest) => {
 
     const orderedData = orderingData(mappedData, order);
 
-    return Response.json(orderedData);
+    const pageSize = 20;
+
+    const paginated = orderedData.goods.slice(
+      (page - 1) * pageSize,
+      page * pageSize
+    );
+
+    return Response.json({
+      goods: paginated,
+      totalResults: orderedData.totalResults,
+    });
   } catch {
     return new Response(JSON.stringify({ message: "Internal Server Error" }), {
       status: 500,
@@ -839,6 +849,7 @@ const parseSearchParams = (params: URLSearchParams) => {
   return {
     q: params.get("q") ?? "",
     order: (params.get("order") ?? "recommended") as Order,
+    page: Number(params.get("page") ?? "1"),
   };
 };
 

--- a/src/features/goods/detail/api/getGoodsDetail.ts
+++ b/src/features/goods/detail/api/getGoodsDetail.ts
@@ -62,9 +62,9 @@ export type GetGoodsDetailResponse = {
 export const GetGoodsDetailURL = `${API_BASE_URL}/api/goods/detail/:goodId`;
 
 export const getGoodsDetail = async (
-  params: GetGoodsDetailRequestParams
+  goodId: GetGoodsDetailRequestParams["goodId"]
 ): Promise<GetGoodsDetailResponse> => {
-  const url = GetGoodsDetailURL.replace(":goodId", params.goodId);
+  const url = GetGoodsDetailURL.replace(":goodId", goodId);
 
   const { data } = await api.get(url);
 

--- a/src/features/goods/detail/components/GoodDetail/index.tsx
+++ b/src/features/goods/detail/components/GoodDetail/index.tsx
@@ -1,15 +1,19 @@
 "use client";
 
-import { GetGoodsDetailRequestParams } from "../../api/getGoodsDetail";
-import { useGetGoodsDetail } from "../../hooks/useGetGoodsDetail";
-import { ThumbnailSwiper } from "../ThumbnailSwiper";
-import { GoodDescription } from "../Description";
+import { GetGoodsDetailRequestParams } from "@/features/goods/detail/api/getGoodsDetail";
+import { useGetGoodsDetail } from "@/features/goods/detail/hooks/useGetGoodsDetail";
+import { ThumbnailSwiper } from "@/features/goods/detail/components/ThumbnailSwiper";
+import { GoodDescription } from "@/features/goods/detail/components/Description";
 import * as s from "./style.css";
 
-type Props = GetGoodsDetailRequestParams;
+type Props = Pick<GetGoodsDetailRequestParams, "goodId">;
 
 export const GoodDetail = ({ goodId }: Props) => {
   const { data } = useGetGoodsDetail({ goodId });
+
+  if (!data) {
+    return;
+  }
 
   const { sub_images } = data;
 

--- a/src/features/goods/detail/hooks/useGetGoodsDetail.ts
+++ b/src/features/goods/detail/hooks/useGetGoodsDetail.ts
@@ -1,21 +1,13 @@
-import {
-  UseSuspenseQueryResult,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
+import { UseQueryResult, useQuery } from "@tanstack/react-query";
 import {
   GetGoodsDetailRequestParams,
   GetGoodsDetailResponse,
-  GetGoodsDetailURL,
-  getGoodsDetail,
-} from "../api/getGoodsDetail";
+} from "@/features/goods/detail/api/getGoodsDetail";
+import { goodDetailQueryOptions } from "@/features/goods/detail/queries/goodDetail";
 
-type Params = GetGoodsDetailRequestParams;
+type Params = Pick<GetGoodsDetailRequestParams, "goodId">;
 
-export const useGetGoodsDetail = (
-  params: Params
-): UseSuspenseQueryResult<GetGoodsDetailResponse, Error> => {
-  return useSuspenseQuery({
-    queryKey: ["goodsDetail", GetGoodsDetailURL, params.goodId],
-    queryFn: async () => await getGoodsDetail(params),
-  });
-};
+export const useGetGoodsDetail = ({
+  goodId,
+}: Params): UseQueryResult<GetGoodsDetailResponse, Error> =>
+  useQuery(goodDetailQueryOptions({ goodId }));

--- a/src/features/goods/detail/queries/goodDetail.ts
+++ b/src/features/goods/detail/queries/goodDetail.ts
@@ -1,0 +1,13 @@
+import { queryOptions } from "@tanstack/react-query";
+import {
+  GetGoodsDetailRequestParams,
+  getGoodsDetail,
+} from "@/features/goods/detail/api/getGoodsDetail";
+
+type Params = Pick<GetGoodsDetailRequestParams, "goodId">;
+
+export const goodDetailQueryOptions = ({ goodId }: Params) =>
+  queryOptions({
+    queryKey: ["goodDetail", goodId],
+    queryFn: async () => await getGoodsDetail(goodId),
+  });

--- a/src/features/main/components/MainGoods/index.tsx
+++ b/src/features/main/components/MainGoods/index.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
 import { useGetGoods } from "@/features/main/hooks/useGetGoods";
-import { Order } from "@/features/main/api/getGoods";
+import { GetGoodsRequestParams } from "@/features/main/api/getGoods";
 import { GoodsGrid } from "@/shared/components/GoodsGrid";
 
-export const MainGoods = () => {
-  const searchParams = useSearchParams();
-  const order = (searchParams?.get("order") ?? "recommended") as Order;
-  const { data, hasNextPage, fetchNextPage, isFetchingNextPage } =
-    useGetGoods(order);
+type Props = Pick<GetGoodsRequestParams, "order">;
 
-  const flatData = data.pages.map((page) => page.goods ?? []).flat();
+export const MainGoods = ({ order }: Props) => {
+  const { data, hasNextPage, fetchNextPage, isFetchingNextPage } = useGetGoods({
+    order,
+  });
+
+  const flatData = data?.pages.map((page) => page.goods ?? []).flat();
 
   return (
     <GoodsGrid

--- a/src/features/main/hooks/useGetGoods.ts
+++ b/src/features/main/hooks/useGetGoods.ts
@@ -1,31 +1,17 @@
 import {
   InfiniteData,
-  UseSuspenseInfiniteQueryResult,
-  useSuspenseInfiniteQuery,
+  UseInfiniteQueryResult,
+  useInfiniteQuery,
 } from "@tanstack/react-query";
 import {
   GetGoodsRequestParams,
   GetGoodsResponse,
-  getGoods,
 } from "@/features/main/api/getGoods";
+import { goodsInfiniteQueryOptions } from "@/features/main/queries/goods";
 
-type Params = GetGoodsRequestParams["order"];
+type Params = Pick<GetGoodsRequestParams, "order">;
 
-export const useGetGoods = (
-  order: Params
-): UseSuspenseInfiniteQueryResult<InfiniteData<GetGoodsResponse>, Error> => {
-  return useSuspenseInfiniteQuery({
-    queryKey: ["goods", order],
-    queryFn: async ({ pageParam = 1 }) => {
-      return await getGoods({ order, page: pageParam });
-    },
-    initialPageParam: 1,
-    getNextPageParam: (lastPage, pages) => {
-      const loadedCount = pages.flatMap((page) => page.goods).length; // 지금까지 로드된 총 데이터 개수
-      const totalResults = lastPage.totalResults; // 서버에서 반환한 전체 데이터 개수
-
-      // 아직 더 가져올 데이터가 있다면 다음 페이지 번호 반환
-      return loadedCount < totalResults ? pages.length + 1 : undefined;
-    },
-  });
-};
+export const useGetGoods = ({
+  order,
+}: Params): UseInfiniteQueryResult<InfiniteData<GetGoodsResponse>, Error> =>
+  useInfiniteQuery(goodsInfiniteQueryOptions({ order }));

--- a/src/features/main/queries/goods.ts
+++ b/src/features/main/queries/goods.ts
@@ -1,0 +1,20 @@
+import { infiniteQueryOptions } from "@tanstack/react-query";
+import { GetGoodsRequestParams, getGoods } from "@/features/main/api/getGoods";
+
+type Params = Pick<GetGoodsRequestParams, "order">;
+
+export const goodsInfiniteQueryOptions = ({ order }: Params) =>
+  infiniteQueryOptions({
+    queryKey: ["goods", order],
+    queryFn: async ({ pageParam = 1 }) => {
+      return await getGoods({ order, page: pageParam });
+    },
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, pages) => {
+      const loadedCount = pages.flatMap((page) => page.goods).length; // 지금까지 로드된 총 데이터 개수
+      const totalResults = lastPage.totalResults; // 서버에서 반환한 전체 데이터 개수
+
+      // 아직 더 가져올 데이터가 있다면 다음 페이지 번호 반환
+      return loadedCount < totalResults ? pages.length + 1 : undefined;
+    },
+  });

--- a/src/features/search/api/getSearchGoods.ts
+++ b/src/features/search/api/getSearchGoods.ts
@@ -6,6 +6,7 @@ import { api } from "@/shared/lib/axios";
 export type GetSearchGoodsRequestParams = {
   q: string;
   order: Order;
+  page: number;
 };
 
 export type GetSearchGoodsResponse = GetGoodsResponse;

--- a/src/features/search/components/SearchGoods/index.tsx
+++ b/src/features/search/components/SearchGoods/index.tsx
@@ -1,30 +1,26 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
 import { useGetSearchGoods } from "@/features/search/hooks/useGetSearchGoods";
-import { Order } from "@/features/main/api/getGoods";
+import { GetSearchGoodsRequestParams } from "@/features/search/api/getSearchGoods";
 import Empty from "@/features/search/components/SearchGoods/empty.svg";
 import { formatNumberWithCommas } from "@/shared/utils/format/number";
 import { GoodsGrid } from "@/shared/components/GoodsGrid";
 import * as s from "@/features/search/components/SearchGoods/style.css";
 
-export const SearchGoods = () => {
-  const searchParams = useSearchParams();
-  const searchQuery = {
-    q: searchParams?.get("q") ?? "",
-    order: (searchParams?.get("order") ?? "recommended") as Order,
-  };
+type Props = Pick<GetSearchGoodsRequestParams, "q" | "order">;
 
+export const SearchGoods = ({ q, order }: Props) => {
   const { data, hasNextPage, fetchNextPage, isFetchingNextPage } =
-    useGetSearchGoods(searchQuery);
+    useGetSearchGoods({ q, order });
 
-  const flatData = data.pages.map((page) => page.goods ?? []).flat();
+  const flatData = data?.pages.map((page) => page.goods ?? []).flat();
 
   return (
     <>
       <div className={s.totalWrapper}>
         <h6 className={s.total}>
-          전체 {formatNumberWithCommas(data?.pages?.[0]?.totalResults)}
+          전체{" "}
+          {formatNumberWithCommas(data ? data?.pages?.[0]?.totalResults : 0)}
         </h6>
       </div>
       <GoodsGrid

--- a/src/features/search/hooks/useGetSearchGoods.ts
+++ b/src/features/search/hooks/useGetSearchGoods.ts
@@ -1,33 +1,20 @@
 import {
   InfiniteData,
-  UseSuspenseInfiniteQueryResult,
-  useSuspenseInfiniteQuery,
+  UseInfiniteQueryResult,
+  useInfiniteQuery,
 } from "@tanstack/react-query";
 import {
   GetSearchGoodsRequestParams,
   GetSearchGoodsResponse,
-  getSearchGoods,
-  getSearchGoodsURL,
-} from "../api/getSearchGoods";
+} from "@/features/search/api/getSearchGoods";
+import { searchGoodsInfiniteQueryOptions } from "@/features/search/queries/searchGoods";
 
-type Params = GetSearchGoodsRequestParams;
+type Params = Pick<GetSearchGoodsRequestParams, "q" | "order">;
 
 export const useGetSearchGoods = ({
   q,
   order,
-}: Params): UseSuspenseInfiniteQueryResult<
+}: Params): UseInfiniteQueryResult<
   InfiniteData<GetSearchGoodsResponse>,
   Error
-> => {
-  return useSuspenseInfiniteQuery({
-    queryKey: ["search", getSearchGoodsURL, q, order],
-    queryFn: async () => await getSearchGoods({ q, order }),
-    initialPageParam: 1,
-    getNextPageParam: (lastPage, pages) => {
-      const loadedCount = pages.flatMap((page) => page.goods).length;
-      const totalResults = lastPage.totalResults;
-
-      return loadedCount < totalResults ? pages.length + 1 : undefined;
-    },
-  });
-};
+> => useInfiniteQuery(searchGoodsInfiniteQueryOptions({ q, order }));

--- a/src/features/search/queries/searchGoods.ts
+++ b/src/features/search/queries/searchGoods.ts
@@ -1,0 +1,21 @@
+import { infiniteQueryOptions } from "@tanstack/react-query";
+import {
+  GetSearchGoodsRequestParams,
+  getSearchGoods,
+} from "@/features/search/api/getSearchGoods";
+
+type Params = Pick<GetSearchGoodsRequestParams, "q" | "order">;
+
+export const searchGoodsInfiniteQueryOptions = ({ q, order }: Params) =>
+  infiniteQueryOptions({
+    queryKey: ["search", q, order],
+    queryFn: async ({ pageParam }) =>
+      await getSearchGoods({ q, order, page: pageParam }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, pages) => {
+      const loadedCount = pages.flatMap((page) => page.goods).length;
+      const totalResults = lastPage.totalResults;
+
+      return loadedCount < totalResults ? pages.length + 1 : undefined;
+    },
+  });

--- a/src/shared/components/GoodsGrid/index.tsx
+++ b/src/shared/components/GoodsGrid/index.tsx
@@ -10,7 +10,7 @@ import { VisibilityLoader } from "@/shared/components/VisibilityLoader";
 import * as s from "@/shared/components/GoodsGrid/style.css";
 
 type Props = {
-  goods: Good[];
+  goods: Good[] | undefined;
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
   fetchNextPage: (
@@ -22,7 +22,7 @@ type Props = {
 };
 
 export const GoodsGrid = ({
-  goods,
+  goods = [],
   hasNextPage,
   isFetchingNextPage,
   fetchNextPage,

--- a/src/shared/components/QueryProvider/index.tsx
+++ b/src/shared/components/QueryProvider/index.tsx
@@ -1,28 +1,20 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryStreamedHydration } from "@tanstack/react-query-next-experimental";
-import { useState } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { getQueryClient } from "@/shared/lib/react-query";
 
 type Props = {
   children: React.ReactNode;
 };
 
 export const QueryProvider = ({ children }: Props) => {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            staleTime: 60 * 1000,
-          },
-        },
-      })
-  );
+  const queryClient = getQueryClient();
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ReactQueryStreamedHydration>{children}</ReactQueryStreamedHydration>
+      {children}
+      <ReactQueryDevtools />
     </QueryClientProvider>
   );
 };

--- a/src/shared/lib/react-query.ts
+++ b/src/shared/lib/react-query.ts
@@ -1,0 +1,37 @@
+import {
+  QueryClient,
+  defaultShouldDehydrateQuery,
+  isServer,
+} from "@tanstack/react-query";
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+      },
+      dehydrate: {
+        // include pending queries in dehydration
+        shouldDehydrateQuery: (query) =>
+          defaultShouldDehydrateQuery(query) ||
+          query.state.status === "pending",
+      },
+    },
+  });
+}
+
+let browserQueryClient: QueryClient | undefined = undefined;
+
+export function getQueryClient() {
+  if (isServer) {
+    // Server: always make a new query client
+    return makeQueryClient();
+  } else {
+    // Browser: make a new query client if we don't already have one
+    // This is very important, so we don't re-make a new client if React
+    // suspends during the initial render. This may not be needed if we
+    // have a suspense boundary BELOW the creation of the query client
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,10 +2715,17 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.62.3.tgz#7cfde68f7d78807faebee2a2bb1e31b81067f46b"
   integrity sha512-Jp/nYoz8cnO7kqhOlSv8ke/0MJRJVGuZ0P/JO9KQ+f45mpN90hrerzavyTKeSoT/pOzeoOUkv1Xd0wPsxAWXfg==
 
-"@tanstack/react-query-next-experimental@^5.62.3":
-  version "5.62.3"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-query-next-experimental/-/react-query-next-experimental-5.62.3.tgz#aa76b39f2ba918617fca8591bda6a8eda62936e1"
-  integrity sha512-RgYGLIb12alB6Yd3StknzKcWOpPerPCfNtlp69TiDRLrXtHc5L8gPqC5uVqM2lPRoUbj32FrVUmfSEmLhlVl6A==
+"@tanstack/query-devtools@5.76.0":
+  version "5.76.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.76.0.tgz#ba43754ed8d23a265ed72f17de618fa9f9c7649d"
+  integrity sha512-1p92nqOBPYVqVDU0Ua5nzHenC6EGZNrLnB2OZphYw8CNA1exuvI97FVgIKON7Uug3uQqvH/QY8suUKpQo8qHNQ==
+
+"@tanstack/react-query-devtools@^5.76.1":
+  version "5.76.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-5.76.1.tgz#20157a5880df5fd4d4fe8fd4fca2c8663d8dfa3e"
+  integrity sha512-LFVWgk/VtXPkerNLfYIeuGHh0Aim/k9PFGA+JxLdRaUiroQ4j4eoEqBrUpQ1Pd/KXoG4AB9vVE/M6PUQ9vwxBQ==
+  dependencies:
+    "@tanstack/query-devtools" "5.76.0"
 
 "@tanstack/react-query@^5.62.3":
   version "5.62.3"


### PR DESCRIPTION
refactor: react-query를 streaming 방식에서 prefetch 방식으로 전환
feat: prefetch 방식 적용을 위해 main 페이지 서버 컴포넌트에 prefetch 로직 추가
feat: prefetch 방식 적용을 위해 search 페이지의 서버 컴포넌트에 prefetch 로직 추가
refactor: goodsInfiniteQueryOptions 파일명을 goods로 변경
feat: prefetch 방식 적용을 위해 goods/[goodId] 페이지의 서버 컴포넌트에 prefetch 로직 추가
refactor: MainGoods 컴포넌트에서 searchParams 값을 useSearchParams 가 아닌 서버 컴포넌트로부터 props 형태로 전달받도록 수정
refactor: SearchGoods 컴포넌트에서 searchParams 값을 useSearchParams 가 아닌 서버 컴포넌트로부터 props 형태로 전달받도록 수정
refactor: main 페이지, MainGoods, goodsInfiniteQueryOptions, useGetGoods 의 Params와 Props 타입 수정
refactor: goods/[goodId] 페이지, GoodDetail, goodDetailQueryOptions, useGetGoodsDetail 의 Params와 Props 타입 수정