### PR TITLE
fix: 미들웨어에 토큰 유효성 검사 추가하여 무한 리다이렉트 문제 해결

### DIFF
--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -3,25 +3,21 @@ import { reissueAccessToken } from "@/shared/server/auth";
 import { ACCESS_TOKEN } from "@/shared/constants/client";
 
 export const POST = async () => {
-  try {
-    const newAccessToken = await reissueAccessToken();
+  const newAccessToken = await reissueAccessToken();
 
-    const response = NextResponse.json({ success: true });
-
-    response.cookies.set(ACCESS_TOKEN, newAccessToken, {
-      httpOnly: true,
-      path: "/",
-    });
-
-    return response;
-  } catch (error) {
-    // refreshToken 값이 존재하지 않습니다.
-    // refreshToken 값이 만료되었습니다.
-    console.warn((error as Error).message);
-
+  if (!newAccessToken) {
     return NextResponse.json(
-      { success: false, message: (error as Error).message },
+      { success: false, message: "access token 재발급에 실패했습니다." },
       { status: 200 }
     );
   }
+
+  const response = NextResponse.json({ success: true });
+
+  response.cookies.set(ACCESS_TOKEN, newAccessToken, {
+    httpOnly: true,
+    path: "/",
+  });
+
+  return response;
 };

--- a/src/shared/lib/axios/errorHandler.ts
+++ b/src/shared/lib/axios/errorHandler.ts
@@ -17,8 +17,13 @@ export const handleError = async (error: AxiosError) => {
   if (isUnauthorized && !originalRequest._retry && !isLoginRequest) {
     originalRequest._retry = true;
     try {
-      await api.post("/auth/refresh");
-      window.location.reload();
+      const { data } = await api.post("/auth/refresh");
+
+      if (!data?.success) {
+        window.location.href = "/login";
+        return;
+      }
+
       return api(originalRequest);
     } catch {
       window.location.href = "/login";

--- a/src/shared/server/auth.ts
+++ b/src/shared/server/auth.ts
@@ -11,23 +11,27 @@ export const signToken = async (payload: JWTPayload, expiresIn: string) => {
     .sign(SECRET);
 };
 
-export const verifyJwt = async (name: string, token: string) => {
+export const verifyJwt = async (
+  token: string | undefined = "",
+  name: string
+) => {
   try {
     const { payload } = await jwtVerify(token, SECRET);
 
     return payload;
   } catch {
-    throw new Error(`${name} 값이 만료되었습니다.`);
+    console.log(`${name}이 만료되었거나 유효하지 않는 토큰입니다.`);
   }
 };
 
 export const reissueAccessToken = async () => {
   const refreshToken = (await cookies()).get(REFRESH_TOKEN)?.value;
 
-  if (!refreshToken)
-    throw new Error(`${REFRESH_TOKEN} 값이 존재하지 않습니다.`);
+  if (!refreshToken) return null;
 
-  const payload = await verifyJwt(REFRESH_TOKEN, refreshToken);
+  const payload = await verifyJwt(refreshToken, REFRESH_TOKEN);
+
+  if (!payload || !payload.email) return null;
 
   return await signToken({ email: payload.email }, "15m");
 };

--- a/src/shared/server/session.ts
+++ b/src/shared/server/session.ts
@@ -7,10 +7,7 @@ export const getSession = async () => {
 
   if (!accessToken) return null;
 
-  try {
-    const payload = await verifyJwt(ACCESS_TOKEN, accessToken);
-    return payload ? { user: payload } : null;
-  } catch {
-    return null;
-  }
+  const payload = await verifyJwt(accessToken, ACCESS_TOKEN);
+
+  return payload ? { user: payload } : null;
 };


### PR DESCRIPTION
## 개요
미들웨어에서 access token의 존재만 확인하던 기존 구조를 개선하여 access token의 유효성을 함께 검사하도록 수정했습니다.
이를 통해 만료된 토큰이 존재하는 경우 잘못된 인증 상태로 판단되어 발생하던 무한 리다이렉트 문제를 해결했습니다.

## 문제 상황
1. 액세스 토큰이 만료된 상태로 사용자가 /cart 경로에 접근
2. 미들웨어는 토큰 존재 여부만 검사하여 인증된 사용자로 판단 → /cart 접근 허용
3. 서버 컴포넌트에서 토큰 유효성 검사를 통해 비인증 상태로 판단 → /login으로 리디렉션
4. /login 접근 시 미들웨어가 토큰이 존재한다는 이유로 다시 /로 리디렉션
5. 그 결과, / → /cart → /login → / 로 이어지는 무한 리다이렉트 루프 발생

## 해결 방법
middleware.ts에서 access token의 존재 여부만이 아닌 유효성 검사까지 거쳐 라우팅을 제어하도록 수정하여 문제 해결
